### PR TITLE
Directly scanning metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ based on pyspark 3.4, which you can install through pip.
 To build the extension with vcpkg, you can build this extension using:
 
 ```shell
-VCPKG_TOOLCHAIN_PATH='<path_to_your_vcpkg_toolchain>' make
+VCPKG_TOOLCHAIN_PATH='<path_to_your_vcpkg_toolchain_cmake_file>' make
 ```
 
 This will build both the separate loadable extension and a duckdb binary with the extension pre-loaded:

--- a/src/iceberg_functions/iceberg_scan.cpp
+++ b/src/iceberg_functions/iceberg_scan.cpp
@@ -223,29 +223,24 @@ static unique_ptr<TableRef> IcebergScanBindReplace(ClientContext &context, Table
 	}
 }
 
-static unique_ptr<FunctionData> IcebergScanBind(ClientContext &context, TableFunctionBindInput &input,
-                                                vector<LogicalType> &return_types, vector<string> &names) {
-	return nullptr;
-}
-
 TableFunctionSet IcebergFunctions::GetIcebergScanFunction() {
 	TableFunctionSet function_set("iceberg_scan");
 
 	auto fun =
-	    TableFunction({LogicalType::VARCHAR}, nullptr, IcebergScanBind, IcebergScanGlobalTableFunctionState::Init);
+	    TableFunction({LogicalType::VARCHAR}, nullptr, nullptr, IcebergScanGlobalTableFunctionState::Init);
 	fun.bind_replace = IcebergScanBindReplace;
 	fun.named_parameters["allow_moved_paths"] = LogicalType::BOOLEAN;
 	fun.named_parameters["mode"] = LogicalType::VARCHAR;
 	function_set.AddFunction(fun);
 
-	fun = TableFunction({LogicalType::VARCHAR, LogicalType::UBIGINT}, nullptr, IcebergScanBind,
+	fun = TableFunction({LogicalType::VARCHAR, LogicalType::UBIGINT}, nullptr, nullptr,
 	                    IcebergScanGlobalTableFunctionState::Init);
 	fun.bind_replace = IcebergScanBindReplace;
 	fun.named_parameters["allow_moved_paths"] = LogicalType::BOOLEAN;
 	fun.named_parameters["mode"] = LogicalType::VARCHAR;
 	function_set.AddFunction(fun);
 
-	fun = TableFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, nullptr, IcebergScanBind,
+	fun = TableFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, nullptr, nullptr,
 	                    IcebergScanGlobalTableFunctionState::Init);
 	fun.bind_replace = IcebergScanBindReplace;
 	fun.named_parameters["allow_moved_paths"] = LogicalType::BOOLEAN;

--- a/src/iceberg_functions/iceberg_scan.cpp
+++ b/src/iceberg_functions/iceberg_scan.cpp
@@ -178,6 +178,9 @@ static unique_ptr<TableRef> IcebergScanBindReplace(ClientContext &context, Table
 		auto loption = StringUtil::Lower(kv.first);
 		if (loption == "allow_moved_paths") {
 			allow_moved_paths = BooleanValue::Get(kv.second);
+			if (StringUtil::EndsWith(iceberg_path, ".json")) {
+				throw InvalidInputException("Enabling allow_moved_paths is not enabled for directly scanning metadata files.");
+			}
 		} else if (loption == "mode") {
 			mode = StringValue::Get(kv.second);
 		}

--- a/src/include/iceberg_metadata.hpp
+++ b/src/include/iceberg_metadata.hpp
@@ -33,7 +33,7 @@ public:
 
 protected:
 	//! Internal JSON parsing functions
-	static idx_t GetTableVersion(string &path, FileSystem &fs);
+	static string GetTableVersion(string &path, FileSystem &fs);
 	static yyjson_val *FindLatestSnapshotInternal(yyjson_val *snapshots);
 	static yyjson_val *FindSnapshotByIdInternal(yyjson_val *snapshots, idx_t target_id);
 	static yyjson_val *FindSnapshotByIdTimestampInternal(yyjson_val *snapshots, timestamp_t timestamp);

--- a/test/sql/iceberg_scan.test
+++ b/test/sql/iceberg_scan.test
@@ -14,7 +14,7 @@ require iceberg
 statement error
 SELECT count(*) FROM ICEBERG_SCAN('data/iceberg/lineitem_iceberg', ALLOW_MOVED_PATHS=TRUE);
 ----
-Catalog Error: Function with name "parquet_scan" is not in the catalog
+Catalog Error
 
 require parquet
 

--- a/test/sql/iceberg_scan_generated_data_0_01.test_slow
+++ b/test/sql/iceberg_scan_generated_data_0_01.test_slow
@@ -30,6 +30,10 @@ SELECT * FROM ICEBERG_SCAN('data/iceberg/generated_spec1_0_01/pyspark_iceberg_ta
 ----
 
 query I nosort q1
+SELECT * FROM ICEBERG_SCAN('data/iceberg/generated_spec1_0_01/pyspark_iceberg_table/metadata/v6.metadata.json') ORDER BY uuid;
+----
+
+query I nosort q1
 SELECT * FROM PARQUET_SCAN('data/iceberg/generated_spec1_0_01/expected_results/q05/data/*.parquet') ORDER BY uuid;
 ----
 
@@ -50,6 +54,11 @@ SELECT count(*) FROM ICEBERG_SCAN('data/iceberg/generated_spec2_0_01/pyspark_ice
 # Check data is identical, sorting by uuid to guarantee unique order
 query I nosort q2
 SELECT * FROM ICEBERG_SCAN('data/iceberg/generated_spec2_0_01/pyspark_iceberg_table') ORDER BY uuid;
+----
+
+# Check data is identical, sorting by uuid to guarantee unique order
+query I nosort q2
+SELECT * FROM ICEBERG_SCAN('data/iceberg/generated_spec2_0_01/pyspark_iceberg_table/metadata/v6.metadata.json') ORDER BY uuid;
 ----
 
 query I nosort q2

--- a/test/sql/iceberg_scan_generated_data_0_01.test_slow
+++ b/test/sql/iceberg_scan_generated_data_0_01.test_slow
@@ -18,6 +18,12 @@ SELECT count(*) FROM ICEBERG_SCAN('data/iceberg/generated_spec1_0_01/pyspark_ice
 ----
 <FILE>:data/iceberg/generated_spec1_0_01/expected_results/last/count.csv
 
+# We should also be able to scan the metadata file directly
+query I
+SELECT count(*) FROM ICEBERG_SCAN('data/iceberg/generated_spec1_0_01/pyspark_iceberg_table/metadata/v6.metadata.json');
+----
+<FILE>:data/iceberg/generated_spec1_0_01/expected_results/last/count.csv
+
 # Check data is identical, sorting by uuid to guarantee unique order
 query I nosort q1
 SELECT * FROM ICEBERG_SCAN('data/iceberg/generated_spec1_0_01/pyspark_iceberg_table') ORDER BY uuid;
@@ -32,6 +38,12 @@ SELECT * FROM PARQUET_SCAN('data/iceberg/generated_spec1_0_01/expected_results/q
 # Check count matches
 query I
 SELECT count(*) FROM ICEBERG_SCAN('data/iceberg/generated_spec2_0_01/pyspark_iceberg_table');
+----
+<FILE>:data/iceberg/generated_spec2_0_01/expected_results/last/count.csv
+
+# We should also be able to scan the metadata file directly
+query I
+SELECT count(*) FROM ICEBERG_SCAN('data/iceberg/generated_spec2_0_01/pyspark_iceberg_table/metadata/v6.metadata.json');
 ----
 <FILE>:data/iceberg/generated_spec2_0_01/expected_results/last/count.csv
 


### PR DESCRIPTION
Partial solution to https://github.com/duckdblabs/duckdb_iceberg/issues/10. 

We now allow directly passing a metadata file. We check if the path is a json file, if it is we just scan that directly. This will allow users to access the various iceberg catalogs through an external tool, then pass the path to the latest to duckdb. 
Until we have proper support for iceberg catalogs, this will allow actually using the iceberg extension on systems that don't produce a version-hint file:
```
SELECT * FROM ICEBERG_SCAN('../<metadata_file_name>.json');
```